### PR TITLE
fix symlink permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ services:
     image: spoked/iceberg:latest
     container_name: Iceberg
     restart: unless-stopped
+    environment:
+      - PUID=999
+      - GUID=999
     ports:
       - "4173:4173"
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+set -u
+
+echo "Starting Iceberg container..."
+
+# Check for required environment variables and validate configuration
+# NOTE: This will be used to check for rclone flags and other configuration later
+# required_vars=("REQUIRED_VAR1" "REQUIRED_VAR2")
+# for var in "${required_vars[@]}"; do
+#     if [ -z "${!var:-}" ]; then
+#         echo "Error: Required environment variable '$var' not set."
+#         exit 1
+#     fi
+# done
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+addgroup -g $PGID iceberg
+adduser -D -u $PUID -G iceberg iceberg
+chown -R iceberg:iceberg /iceberg
+chmod -R 755 /iceberg
+
+trap "echo 'Shutting down...'; exit" SIGINT SIGTERM
+echo "Initialization complete. Executing main process..."
+exec "$@"


### PR DESCRIPTION
Allow users to set PUID/PGID in compose. If this doesn't get set, Plex won't see the Symlink files as Plex typically isn't ran as the root users. Make sure to set the PUID and PGID in your compose to the same as what Plex uses.