### PR TITLE
set scrape type to series instad of show. invalid url before.

### DIFF
--- a/backend/program/scrapers/torrentio.py
+++ b/backend/program/scrapers/torrentio.py
@@ -109,11 +109,11 @@ class Torrentio:
         with self.minute_limiter:
             if item.type == "season":
                 identifier = f":{item.number}:1"
-                scrape_type = "show"
+                scrape_type = "series"
                 imdb_id = item.parent.imdb_id
             elif item.type == "episode":
                 identifier = f":{item.parent.number}:{item.number}"
-                scrape_type = "show"
+                scrape_type = "series"
                 imdb_id = item.parent.parent.imdb_id
             else:
                 identifier = None


### PR DESCRIPTION
- Fixes the random 500: handler error's.

This was due to the url being incorrect in the torrentio links when scraping.