### PR TITLE
Rename Symlink paths to improve clarity

### DIFF
--- a/backend/program/plex.py
+++ b/backend/program/plex.py
@@ -37,7 +37,7 @@ class Plex(threading.Thread):
         self.key = "plex"
         self.initialized = False
         self.library_path = os.path.abspath(
-            os.path.dirname(settings.get("symlink.container_path"))
+            os.path.dirname(settings.get("symlink.library_path"))
         )
         self.last_fetch_times = {}
 

--- a/backend/program/symlink.py
+++ b/backend/program/symlink.py
@@ -28,13 +28,12 @@ class Symlinker():
         host_path (str): The absolute path of the host mount.
         symlink_path (str): The path where the symlinks will be created.
     """
-    def __init__(self, _):
+    def __init__(self, *_):
         self.key = "symlink"
         self.settings = SymlinkConfig(**settings.get(self.key))
         self.initialized = self.validate()
         if not self.initialized:
-            logger.error("Symlink initialization failed due to invalid configuration.")
-            return
+            raise ValueError("Symlink initialization failed due to invalid configuration.")
         logger.info("Rclone path symlinks are pointed to: %s", self.settings.host_path)
         logger.info("Symlinks will be placed in: %s", self.library_path)
         logger.info("Symlink initialized!")

--- a/backend/program/symlink.py
+++ b/backend/program/symlink.py
@@ -1,7 +1,7 @@
 """Symlinking module"""
 import os
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 from pydantic import BaseModel
 from utils.settings import settings_manager as settings
 from utils.logger import logger

--- a/backend/program/symlink.py
+++ b/backend/program/symlink.py
@@ -37,9 +37,7 @@ class Symlinker():
     def validate(self):
         """Validate paths and create the initial folders."""
         for name, path in self.settings.__iter__():
-            if name == "symlink_path" and path is None:
-                continue
-            elif path == Path('.'):
+            if path == Path('.'):
                 logger.error(f"{name} is set to the current directory.")
                 return False
             elif not path.is_absolute():
@@ -48,6 +46,9 @@ class Symlinker():
             elif not path.is_dir():
                 logger.error(f"{name} is not a directory or does not exist: {path}")
                 return False
+        if str(self.settings.rclone_path) in str(self.settings.library_path):
+            logger.error(f"library_path is a sub (or the same) directory of rclone_path")
+            return False
         try:
             if (all_path := self.settings.rclone_path / "__all__").exists() and all_path.is_dir():
                 logger.debug("Detected Zurg host path. Using __all__ folder for host path.")

--- a/backend/tests/test_symlink.py
+++ b/backend/tests/test_symlink.py
@@ -22,9 +22,10 @@ def mock_logger():
 @pytest.mark.parametrize(
     "path_settings,expected_error",
     [
-        ({"library_path": "/abs/path", "rclone_path": "."}, "set to the current directory"),
-        ({"rclone_path": "/abs/path", "rclone_path": "rel/"}, "not an absolute path"),
+        ({"rclone_path": ".", "library_path": "."}, "set to the current directory"),
+        ({"rclone_path": "rel/", "library_path": "rel/"}, "not an absolute path"),
         ({"rclone_path": "/abs/path", "library_path": "/abs/path"}, "does not exist"),
+        ({"rclone_path": "/", "library_path": "/"}, "sub (or the same) directory"),
     ],
 )
 def test_symlinker_validate_fails(
@@ -34,14 +35,13 @@ def test_symlinker_validate_fails(
     with pytest.raises(ValueError):
         symlinker = Symlinker()
 
-        error_messages = [call.args[0] for call in mock_logger.error.call_args_list]
-        assert any(expected_error in message for message in error_messages)
-        assert not symlinker.initialized
+    error_messages = [call.args[0] for call in mock_logger.error.call_args_list]
+    assert any([expected_error in message for message in error_messages])
 
 
 def test_library_paths_exists(mock_settings_get, tmp_path):
     test_cases = [
-        ({"rclone_path": tmp_path, "library_path": tmp_path}, tmp_path.parent),
+        ({"rclone_path": tmp_path, "library_path": tmp_path.parent}, tmp_path.parent),
     ]
     with patch("program.symlink.Path.is_dir") as mock_is_dir:
         mock_is_dir.return_value = True

--- a/backend/tests/test_symlink.py
+++ b/backend/tests/test_symlink.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+import pytest
+
+from program.symlink import Symlinker, SymlinkConfig
+from utils.settings import settings_manager as settings
+
+
+@pytest.fixture
+def mock_settings_get():
+    with patch("utils.settings.SettingsManager.get") as mock_get:
+        yield mock_get
+
+
+@pytest.fixture
+def mock_logger():
+    with patch("program.symlink.logger") as mock_log:
+        yield mock_log
+
+
+base_settings = {
+    "host_path": "/abs/path",
+    "container_path": "/abs/path",
+    "symlink_path": "/abs/path",
+}
+
+
+@pytest.mark.parametrize(
+    "path_settings,expected_error",
+    [
+        ({**base_settings, **{"host_path": "."}}, "set to the current directory"),
+        ({**base_settings, **{"host_path": "rel/"}}, "not an absolute path"),
+        (base_settings, "does not exist"),
+    ],
+)
+def test_symlinker_validate_fails(
+    mock_settings_get, mock_logger, path_settings, expected_error
+):
+    mock_settings_get.return_value = path_settings
+    with pytest.raises(ValueError):
+        symlinker = Symlinker()
+
+        error_messages = [call.args[0] for call in mock_logger.error.call_args_list]
+        assert any(expected_error in message for message in error_messages)
+        assert not symlinker.initialized
+
+
+def test_library_paths_exists(mock_settings_get, tmp_path):
+    test_cases = [
+        (
+            {
+                "host_path": tmp_path.parent,
+                "symlink_path": tmp_path,
+                "container_path": tmp_path.parent,
+            },
+            tmp_path,
+        ),
+        ({"host_path": tmp_path, "container_path": tmp_path}, tmp_path.parent),
+    ]
+    with patch("program.symlink.Path.is_dir") as mock_is_dir:
+        mock_is_dir.return_value = True
+        for path_settings, test_path in test_cases:
+            mock_settings_get.return_value = path_settings
+            symlinker = Symlinker()
+            assert symlinker.create_initial_folders() == True
+            for name, folder in symlinker.__dict__.items():
+                if not name.startswith("library_path"):
+                    continue
+                assert str(test_path) in str(folder)

--- a/backend/tests/test_symlink.py
+++ b/backend/tests/test_symlink.py
@@ -19,19 +19,12 @@ def mock_logger():
         yield mock_log
 
 
-base_settings = {
-    "host_path": "/abs/path",
-    "container_path": "/abs/path",
-    "symlink_path": "/abs/path",
-}
-
-
 @pytest.mark.parametrize(
     "path_settings,expected_error",
     [
-        ({**base_settings, **{"host_path": "."}}, "set to the current directory"),
-        ({**base_settings, **{"host_path": "rel/"}}, "not an absolute path"),
-        (base_settings, "does not exist"),
+        ({"library_path": "/abs/path", "rclone_path": "."}, "set to the current directory"),
+        ({"rclone_path": "/abs/path", "rclone_path": "rel/"}, "not an absolute path"),
+        ({"rclone_path": "/abs/path", "library_path": "/abs/path"}, "does not exist"),
     ],
 )
 def test_symlinker_validate_fails(
@@ -48,15 +41,7 @@ def test_symlinker_validate_fails(
 
 def test_library_paths_exists(mock_settings_get, tmp_path):
     test_cases = [
-        (
-            {
-                "host_path": tmp_path.parent,
-                "symlink_path": tmp_path,
-                "container_path": tmp_path.parent,
-            },
-            tmp_path,
-        ),
-        ({"host_path": tmp_path, "container_path": tmp_path}, tmp_path.parent),
+        ({"rclone_path": tmp_path, "library_path": tmp_path}, tmp_path.parent),
     ]
     with patch("program.symlink.Path.is_dir") as mock_is_dir:
         mock_is_dir.return_value = True

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+black


### PR DESCRIPTION
I had placed the symlink directory in the rclone directory due to a misunderstanding of both the variable names and the expected outcome.  This PR aims to improve the clarity of the names, as well as simplify and expand the path validation.