### PR TITLE
Alternate startup logic to correctly wait on services to validate

### DIFF
--- a/backend/program/libaries/plex.py
+++ b/backend/program/libaries/plex.py
@@ -13,8 +13,7 @@ from program.media.item import (
     Movie,
     Show,
     Season,
-    Episode,
-    ItemId
+    Episode
 )
 
 class PlexLibrary():

--- a/backend/program/libaries/symlink.py
+++ b/backend/program/libaries/symlink.py
@@ -27,7 +27,7 @@ class SymlinkLibrary:
     def validate(self) -> bool:
         status = all(
             os.path.exists(self.settings.library_path / d) 
-            for d in ( "shows", "movies", "anime_shows", "anime_movies")
+            for d in ("shows", "movies")
         )
         if not status:
             folders = os.listdir(self.settings.library_path)

--- a/backend/program/libaries/symlink.py
+++ b/backend/program/libaries/symlink.py
@@ -19,7 +19,21 @@ class SymlinkLibrary:
         self.last_fetch_times = {}
         self.settings = settings_manager.settings.symlink
         self.initialized = True
-
+        self.initialized = self.validate()
+        if not self.initialized:
+            logger.error("SymlinkLibrary initialization failed due to invalid configuration.")
+            return
+    
+    def validate(self) -> bool:
+        status = all(
+            os.path.exists(self.settings.library_path / d) 
+            for d in ( "shows", "movies", "anime_shows", "anime_movies")
+        )
+        if not status:
+            folders = os.listdir(self.settings.library_path)
+            logger.debug("library dir contains %s", ", ".join(folders))
+        return status
+    
     def run(self) -> MediaItem:
         """Create a library from the symlink paths.  Return stub items that should
         be fed into an Indexer to have the rest of the metadata filled in."""

--- a/backend/program/settings/models.py
+++ b/backend/program/settings/models.py
@@ -1,4 +1,5 @@
 """Iceberg settings models"""
+from typing import Callable
 from pathlib import Path
 from pydantic import BaseModel, HttpUrl, validator
 from utils import version_file_path
@@ -9,7 +10,7 @@ class Observable(BaseModel):
         arbitrary_types_allowed = True
 
     # Assuming _notify_observers is a static method or class-level attribute
-    _notify_observers = None
+    _notify_observers: Callable = None
 
     # This method sets the change notifier on the class, not an instance
     @classmethod

--- a/backend/program/settings/models.py
+++ b/backend/program/settings/models.py
@@ -9,10 +9,8 @@ class Observable(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    # Assuming _notify_observers is a static method or class-level attribute
     _notify_observers: Callable = None
 
-    # This method sets the change notifier on the class, not an instance
     @classmethod
     def set_notify_observers(cls, notify_observers_callable):
         cls._notify_observers = notify_observers_callable


### PR DESCRIPTION
SymlinkLibrary needed a validation step, and also needs to be moved to start after Symlinker to make sure the correct paths are created.  Additionally we should be waiting for all services to validate like we used to. 